### PR TITLE
Documentation fixes and cloudos-cli version bump to 1.0.0

### DIFF
--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Print cloudos job run command (dry_run set to true)
-        uses: lifebit-ai/action-cloudos-cli@0.1.0
+        uses: lifebit-ai/action-cloudos-cli@0.1.1
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_APIKEY }}

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Print cloudos job run command (dry_run set to true)
-        uses: ./ # Uses an action in the root directory
+        uses: lifebit-ai/action-cloudos-cli@0.1.0
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_APIKEY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM quay.io/lifebitaiorg/cloudos-py:v0.1.2
+FROM quay.io/lifebitaiorg/cloudos-cli:v1.0.0
 
 # installes required packages for our script
 RUN	apt install -y \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Echo cloudos command
-        uses: lifebit-ai/action-cloudos-cli@0.1.0
+        uses: lifebit-ai/action-cloudos-cli@0.1.1
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_APIKEY }}

--- a/README.md
+++ b/README.md
@@ -116,6 +116,6 @@ Specific Cromwell server authentication token. Only required for WDL jobs.
 ### `repository_platform`
 
 Name of the repository platform of the workflow. Default=github.
-### `cloudos_cli_flag`
+### `cloudos_cli_flags`
 
 Additional cloudos-cli flags, space separated eg `'--spot --resumable'`. Available options: `[--spot, --batch, --resumable, --verbose, --wait-completion]`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Echo cloudos command
-        uses: lifebit-ai/action-cloudos-cli@v0.1.0
+        uses: lifebit-ai/action-cloudos-cli@0.1.0
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_APIKEY }}


### PR DESCRIPTION
This PR is a release of the latest documentation fixes, and version bump for the action and the cli.