### PR TITLE
Updates the base image for cloudos-cli to latest stable 1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM quay.io/lifebitaiorg/cloudos-py:v0.1.2
+FROM quay.io/lifebitaiorg/cloudos-cli:v1.0.0
 
 # installes required packages for our script
 RUN	apt install -y \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Echo cloudos command
-        uses: lifebit-ai/action-cloudos-cli@0.1.0
+        uses: lifebit-ai/action-cloudos-cli@0.1.1
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_APIKEY }}


### PR DESCRIPTION
This PR updates the the base image for cloudos-cli to latest stable 1.0.0 to inherit all the newest functionality from the cli.