### PR TITLE
Adds request_interval and cost_limit

### DIFF
--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -23,4 +23,6 @@ jobs:
           instance_type: 't3.micro'
           instance_disk: 40
           wait_time: 7200
-          
+          cost_limit: 0.1
+
+

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -12,7 +12,7 @@ jobs:
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_APIKEY }}
-          cloudos_url: 'https://cloudos.lifebit.ai'
+          cloudos_url: 'https://staging.lifebit.ai'
           workspace_id: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
           project_name: 'cloudos-cli-tests'
           workflow_name: 'rnatoy'

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -20,7 +20,7 @@ jobs:
           cloudos_cli_flags: '--resumable --spot --verbose --wait-completion'
           request_interval: 60
           dry_run: 'false'
-          instance_type: 't3.micro'
+          instance_type: 'c5.xlarge'
           instance_disk: 40
           wait_time: 7200
           cost_limit: 0.1

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -3,12 +3,12 @@ on: [push]
 jobs:
   custom_test:
     runs-on: ubuntu-latest
-    name: Dry run test for cloudos job run
+    name: Test for cloudos job run
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Print cloudos job run command (dry_run set to true)
-        uses: lifebit-ai/action-cloudos-cli@0.1.1
+        uses: lifebit-ai/action-cloudos-cli@0.2.0
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_APIKEY }}
@@ -17,5 +17,10 @@ jobs:
           project_name: 'cloudos-cli-tests'
           workflow_name: 'cgpu/rnatoy'
           nextflow_profile: 'test'
-          cloudos_cli_flags: '--resumable --spot'
-          dry_run: 'true'
+          cloudos_cli_flags: '--resumable --spot --verbose --wait-completion'
+          request_interval: 60
+          dry_run: 'false'
+          instance_type: 't3.micro'
+          instance_disk: 40
+          wait_time: 7200
+          

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -15,7 +15,7 @@ jobs:
           cloudos_url: 'https://cloudos.lifebit.ai'
           workspace_id: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
           project_name: 'cloudos-cli-tests'
-          workflow_name: 'cgpu/rnatoy'
+          workflow_name: 'rnatoy'
           nextflow_profile: 'test'
           cloudos_cli_flags: '--resumable --spot --verbose --wait-completion'
           request_interval: 60

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM quay.io/lifebitaiorg/cloudos-cli:v1.0.0
+FROM quay.io/lifebitaiorg/cloudos-cli:v1.1.0
 
 # installes required packages for our script
 RUN	apt install -y \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Echo cloudos command
-        uses: lifebit-ai/action-cloudos-cli@0.1.1
+        uses: lifebit-ai/action-cloudos-cli@0.2.0
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_APIKEY }}
@@ -116,6 +116,11 @@ Specific Cromwell server authentication token. Only required for WDL jobs.
 ### `repository_platform`
 
 Name of the repository platform of the workflow. Default=github.
+
+### `request_interval`
+
+Request interval in seconds. The options is influencing the request interval for receiving the job status when `--wait-completion` is used. The default value is the same as the default of [](https://github.com/lifebit-ai/cloudos-cli).
+
 ### `cloudos_cli_flags`
 
 Additional cloudos-cli flags, space separated eg `'--spot --resumable'`. Available options: `[--spot, --batch, --resumable, --verbose, --wait-completion]`

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ Specific Cromwell server authentication token. Only required for WDL jobs.
 
 Name of the repository platform of the workflow. Default=github.
 
+### `cost_limit`
+
+Cost limit in USD. If the job exceeds the defined cost limit, the job will be aborted. :warning: It is advised to always use a cost limit to avoid jobs running indefinitely if there is a pipeline issue.
 ### `request_interval`
 
 Request interval in seconds. The options is influencing the request interval for receiving the job status when `--wait-completion` is used. The default value is the same as the default of [](https://github.com/lifebit-ai/cloudos-cli).
@@ -124,3 +127,4 @@ Request interval in seconds. The options is influencing the request interval for
 ### `cloudos_cli_flags`
 
 Additional cloudos-cli flags, space separated eg `'--spot --resumable'`. Available options: `[--spot, --batch, --resumable, --verbose, --wait-completion]`
+

--- a/action.yaml
+++ b/action.yaml
@@ -63,6 +63,9 @@ inputs:
   repository_platform:
     description: 'Name of the repository platform of the workflow. Default=github.'
     required: false
+  request_interval: 'Request interval in seconds. The options is influencing the request interval for receiving the job status when --wait-completion is used'
+    description: 
+    required: false
   cloudos_cli_flags:
     description: 'Additional cloudos-cli flags, space separated eg "--spot --resumable". Available options: [--spot, --batch, --resumable, --verbose, --wait-completion]'
     required: false
@@ -94,5 +97,6 @@ runs:
     - ${{ inputs.wdl_importsfile }}
     - ${{ inputs.cromwell_token }}
     - ${{ inputs.repository_platform }}
+    - ${{ inputs.request_interval}}
     - ${{ inputs.cloudos_cli_flags}}
     - ${{ inputs.dry_run}}

--- a/action.yaml
+++ b/action.yaml
@@ -66,6 +66,7 @@ inputs:
   request_interval: 'Request interval in seconds. The options is influencing the request interval for receiving the job status when --wait-completion is used'
     description: 
     required: false
+    default: 50
   cloudos_cli_flags:
     description: 'Additional cloudos-cli flags, space separated eg "--spot --resumable". Available options: [--spot, --batch, --resumable, --verbose, --wait-completion]'
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -66,6 +66,9 @@ inputs:
   request_interval: 
     description: 'Request interval in seconds. The options is influencing the request interval for receiving the job status when --wait-completion is used'
     required: false
+  cost_limit:
+    description: 'Cost limit in USD. If the job exceeds the defined cost limit, the job will be aborted. It is advised to always use a cost limit.'
+    required: false
   cloudos_cli_flags:
     description: 'Additional cloudos-cli flags, space separated eg "--spot --resumable". Available options: [--spot, --batch, --resumable, --verbose, --wait-completion]'
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -63,8 +63,8 @@ inputs:
   repository_platform:
     description: 'Name of the repository platform of the workflow. Default=github.'
     required: false
-  request_interval: 'Request interval in seconds. The options is influencing the request interval for receiving the job status when --wait-completion is used'
-    description: 
+  request_interval: 
+    description: 'Request interval in seconds. The options is influencing the request interval for receiving the job status when --wait-completion is used'
     required: false
     default: 50
   cloudos_cli_flags:

--- a/action.yaml
+++ b/action.yaml
@@ -66,7 +66,6 @@ inputs:
   request_interval: 
     description: 'Request interval in seconds. The options is influencing the request interval for receiving the job status when --wait-completion is used'
     required: false
-    default: 50
   cloudos_cli_flags:
     description: 'Additional cloudos-cli flags, space separated eg "--spot --resumable". Available options: [--spot, --batch, --resumable, --verbose, --wait-completion]'
     required: false
@@ -74,7 +73,7 @@ inputs:
   dry_run:
     description: 'Mode of execution for the action, by default the API call will be sent. Set to dry_run: true if you only want to print the command (strips secrets before printing).'
     required: false
-    default: ''
+    default: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,6 +24,7 @@ if [[ ${INPUT_WDL_IMPORTSFILE} ]];     then CLOUDOS_RUN_CMD+=" --wdl-importsfile
 if [[ ${INPUT_CROMWELL_TOKEN} ]];      then CLOUDOS_RUN_CMD+=" --cromwell-token ${INPUT_CROMWELL_TOKEN}" ; fi
 if [[ ${INPUT_REPOSITORY_PLATFORM} ]]; then CLOUDOS_RUN_CMD+=" --repository-platform ${INPUT_REPOSITORY_PLATFORM}" ; fi
 if [[ ${INPUT_REQUEST_INTERVAL} ]];    then CLOUDOS_RUN_CMD+=" --request-interval ${INPUT_REQUEST_INTERVAL}" ; fi
+if [[ ${INPUT_COST_LIMIT} ]];          then CLOUDOS_RUN_CMD+=" --cost-limit ${INPUT_COST_LIMIT}" ; fi
 if [[ ${INPUT_CLOUDOS_CLI_FLAGS} ]];   then CLOUDOS_RUN_CMD+=" ${INPUT_CLOUDOS_CLI_FLAGS}" ; fi
 
 if [[ ${INPUT_DRY_RUN} != 'true' ]]; then $CLOUDOS_RUN_CMD ; fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,6 +23,7 @@ if [[ ${INPUT_WDL_MAINFILE} ]];        then CLOUDOS_RUN_CMD+=" --wdl-mainfile ${
 if [[ ${INPUT_WDL_IMPORTSFILE} ]];     then CLOUDOS_RUN_CMD+=" --wdl-importsfile ${INPUT_WDL_IMPORTSFILE}" ; fi
 if [[ ${INPUT_CROMWELL_TOKEN} ]];      then CLOUDOS_RUN_CMD+=" --cromwell-token ${INPUT_CROMWELL_TOKEN}" ; fi
 if [[ ${INPUT_REPOSITORY_PLATFORM} ]]; then CLOUDOS_RUN_CMD+=" --repository-platform ${INPUT_REPOSITORY_PLATFORM}" ; fi
+if [[ ${INPUT_REQUEST_INTERVAL} ]];    then CLOUDOS_RUN_CMD+=" --request-interval ${INPUT_REQUEST_INTERVAL}" ; fi
 if [[ ${INPUT_CLOUDOS_CLI_FLAGS} ]];   then CLOUDOS_RUN_CMD+=" ${INPUT_CLOUDOS_CLI_FLAGS}" ; fi
 
 if [[ ${INPUT_DRY_RUN} != 'true' ]]; then $CLOUDOS_RUN_CMD ; fi


### PR DESCRIPTION
## Overview

It adds a new parameter `--request-interval` to the `job run` command, allowing for a custom input of time to request job completion status to the API. An example would be:

```
cloudos job run ... --wait-completion --request-interval 5
```

The constant variable `REQUEST_INTERVAL` is removed, replaced by the `--request-interval`, which has a default value of `30`. The change was also done in `cromwell start` command, to be able to remove the constant.

See PR in https://github.com/lifebit-ai/cloudos-cli/pull/93