### PR TITLE
Add job ID as action output

### DIFF
--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Print cloudos job run command (dry_run set to true)
-        uses: lifebit-ai/action-cloudos-cli@0.2.0
+        uses: lifebit-ai/action-cloudos-cli@0.3.0
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_APIKEY }}
@@ -24,5 +24,7 @@ jobs:
           instance_disk: 40
           wait_time: 7200
           cost_limit: 0.1
+      - name: Get the cloudos_job_run job ID
+        run: echo ${{steps.cloudos_job_run.outputs.job_id}}
 
 

--- a/README.md
+++ b/README.md
@@ -128,3 +128,8 @@ Request interval in seconds. The options is influencing the request interval for
 
 Additional cloudos-cli flags, space separated eg `'--spot --resumable'`. Available options: `[--spot, --batch, --resumable, --verbose, --wait-completion]`
 
+## Outputs
+
+### `job_id`
+
+Job ID extracted from Lifebit CloudOS cloudos-cli.

--- a/action.yaml
+++ b/action.yaml
@@ -63,7 +63,7 @@ inputs:
   repository_platform:
     description: 'Name of the repository platform of the workflow. Default=github.'
     required: false
-  request_interval: 
+  request_interval:
     description: 'Request interval in seconds. The options is influencing the request interval for receiving the job status when --wait-completion is used'
     required: false
   cost_limit:
@@ -77,6 +77,9 @@ inputs:
     description: 'Mode of execution for the action, by default the API call will be sent. Set to dry_run: true if you only want to print the command (strips secrets before printing).'
     required: false
     default: false
+outputs:
+   job_id:
+     description: 'Job ID from Lifebit CloudOS cloudos-cli'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,5 +27,14 @@ if [[ ${INPUT_REQUEST_INTERVAL} ]];    then CLOUDOS_RUN_CMD+=" --request-interva
 if [[ ${INPUT_COST_LIMIT} ]];          then CLOUDOS_RUN_CMD+=" --cost-limit ${INPUT_COST_LIMIT}" ; fi
 if [[ ${INPUT_CLOUDOS_CLI_FLAGS} ]];   then CLOUDOS_RUN_CMD+=" ${INPUT_CLOUDOS_CLI_FLAGS}" ; fi
 
-if [[ ${INPUT_DRY_RUN} != 'true' ]]; then $CLOUDOS_RUN_CMD ; fi
-printf '%s\n' "${CLOUDOS_RUN_CMD//$INPUT_APIKEY/}"
+if [[ ${INPUT_DRY_RUN} != 'true' ]]
+then
+    stdout=$($CLOUDOS_RUN_CMD)
+    echo $stdout
+
+    job_idWithSpace=$(awk -F"Your assigned job id is: |Please, wait until job completion or max wait time of 3600 seconds is reached." '{print $2}' <<< "$stdout")
+    job_id=$(echo $job_idWithSpace | tr -d '\r' | tr -d '\n')
+else
+    job_id=""
+fi
+echo "::set-output name=job_id::$job_id"


### PR DESCRIPTION
## Overview

This PR adds job id as action output

## Changes

- Extracts job id from cloud os cli in: `entrypoint.sh`,
- Adds new output parameter in: `action.yaml`,
- Documents new parameter in: `README.md`.

## How to test

From Ci testing: https://staging.lifebit.ai/app/jobs/635fe58ba661a0015bb196eb

## PR Checklist:

I confirm that:

- [x] all changes/additions are documented
- [x] ci tests added