### PR TITLE
Updates CloudOS container

### DIFF
--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -12,7 +12,7 @@ jobs:
         uses: lifebit-ai/action-cloudos-cli@0.3.1
         id: cloudos_job_run
         with:
-          apikey:  ${{ secrets.CLOUDOS_APIKEY }}
+          apikey:  ${{ secrets.CLOUDOS_TOKEN }}
           cloudos_url: 'https://staging.lifebit.ai'
           workspace_id: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
           project_name: "cloudos-cli-tests"

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -6,12 +6,13 @@ jobs:
     name: Test for cloudos job run
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Print cloudos job run command (dry_run set to true)
+        uses: actions/checkout@v3
+
+      - name: Run cloudos job run command
         uses: lifebit-ai/action-cloudos-cli@0.3.1
         id: cloudos_job_run
         with:
-          apikey:  ${{ secrets.CLOUDOS_APIKEY }}
+          apikey:  ${{ secrets.CLOUDOS_TOKEN }}
           cloudos_url: 'https://staging.lifebit.ai'
           workspace_id: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
           project_name: 'cloudos-cli-tests'
@@ -19,11 +20,12 @@ jobs:
           nextflow_profile: 'test'
           cloudos_cli_flags: '--resumable --spot --verbose --wait-completion'
           request_interval: 60
-          dry_run: 'false'
           instance_type: 'c5.xlarge'
           instance_disk: 40
           wait_time: 7200
+          git_commit: '${{ github.event.pull_request.head.sha }}'
           cost_limit: ${{ secrets.GLOBAL_CLOUDOS_JOB_COST_LIMIT }}
+
       - name: Get the cloudos_job_run job ID
         run: echo ${{steps.cloudos_job_run.outputs.job_id}}
 

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -18,13 +18,11 @@ jobs:
           project_name: 'cloudos-cli-tests'
           workflow_name: 'rnatoy'
           nextflow_profile: 'test'
-          cloudos_cli_flags: '--resumable --spot --verbose --wait-completion'
-          request_interval: 60
-          dry_run: 'false'
-          instance_type: 'c5.xlarge'
-          instance_disk: 40
-          wait_time: 7200
+          git_commit: '${{ github.event.pull_request.head.sha }}'
+          instance_type: 'm5.4xlarge'
+          instance_disk: '40'
           cost_limit: ${{ secrets.GLOBAL_CLOUDOS_JOB_COST_LIMIT }}
+          cloudos_cli_flags: '--spot --wait-completion'
 
       - name: Get the cloudos_job_run job ID
         run: echo ${{steps.cloudos_job_run.outputs.job_id}}

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -15,13 +15,13 @@ jobs:
           apikey:  ${{ secrets.CLOUDOS_TOKEN }}
           cloudos_url: 'https://staging.lifebit.ai'
           workspace_id: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
-          project_name: 'ci-testing'
-          workflow_name: 'etl_profile_clean'
-          nextflow_profile: 'meta_ci_testing'
-          git_commit: '${{ github.event.pull_request.head.sha }}'
-          instance_type: 'm5.4xlarge'
-          instance_disk: '40'
+          project_name: "cloudos-cli-tests"
+          workflow_name: "rnatoy"
+          nextflow_profile: "test"
+          git_commit: "${{ github.event.pull_request.head.sha }}"
+          instance_type: "m5.4xlarge"
+          instance_disk: "40"
           cost_limit: ${{ secrets.GLOBAL_CLOUDOS_JOB_COST_LIMIT }}
-          cloudos_cli_flags: '--spot --wait-completion'
+          cloudos_cli_flags: "--spot --wait-completion"
 
 

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -13,16 +13,16 @@ jobs:
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_TOKEN }}
-          cloudos_url: 'https://staging.lifebit.ai'
+          cloudos_url: "https://staging.lifebit.ai"
           workspace_id: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
-          project_name: 'cloudos-cli-tests'
-          workflow_name: 'rnatoy'
-          nextflow_profile: 'test'
-          git_commit: '${{ github.event.pull_request.head.sha }}'
-          instance_type: 'm5.4xlarge'
-          instance_disk: '40'
+          project_name: "cloudos-cli-tests"
+          workflow_name: "rnatoy"
+          nextflow_profile: "test"
+          git_commit: "${{ github.event.pull_request.head.sha }}"
+          instance_type: "m5.4xlarge"
+          instance_disk: "40"
           cost_limit: ${{ secrets.GLOBAL_CLOUDOS_JOB_COST_LIMIT }}
-          cloudos_cli_flags: '--spot --wait-completion'
+          cloudos_cli_flags: "--spot --wait-completion"
 
       - name: Get the cloudos_job_run job ID
         run: echo ${{steps.cloudos_job_run.outputs.job_id}}

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Print cloudos job run command (dry_run set to true)
-        uses: lifebit-ai/action-cloudos-cli@0.3.1
+        uses: lifebit-ai/action-cloudos-cli@0.3.0
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_TOKEN }}
@@ -21,8 +21,8 @@ jobs:
           instance_type: "m5.4xlarge"
           instance_disk: "40"
           cost_limit: ${{ secrets.GLOBAL_CLOUDOS_JOB_COST_LIMIT }}
-          cloudos_url: "https://staging.lifebit.ai"
           cloudos_cli_flags: "--spot --wait-completion"
+          cloudos_url: "https://staging.lifebit.ai"
 
       - name: Get the cloudos_job_run job ID
         run: echo ${{steps.cloudos_job_run.outputs.job_id}}

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -12,8 +12,8 @@ jobs:
         uses: lifebit-ai/action-cloudos-cli@0.3.1
         id: cloudos_job_run
         with:
-          cloudos_url: "https://staging.lifebit.ai"
           apikey:  ${{ secrets.CLOUDOS_TOKEN }}
+          cloudos_url: 'https://staging.lifebit.ai'
           workspace_id: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
           project_name: "cloudos-cli-tests"
           workflow_name: "rnatoy"

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -23,7 +23,7 @@ jobs:
           instance_type: 'c5.xlarge'
           instance_disk: 40
           wait_time: 7200
-          cost_limit: 0.1
+          cost_limit: ${{ secrets.GLOBAL_CLOUDOS_JOB_COST_LIMIT }}
       - name: Get the cloudos_job_run job ID
         run: echo ${{steps.cloudos_job_run.outputs.job_id}}
 

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -6,14 +6,13 @@ jobs:
     name: Test for cloudos job run
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Print cloudos job run command (dry_run set to true)
         uses: lifebit-ai/action-cloudos-cli@0.3.1
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_TOKEN }}
-          cloudos_url: "https://staging.lifebit.ai"
           workspace_id: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
           project_name: "cloudos-cli-tests"
           workflow_name: "rnatoy"
@@ -22,6 +21,7 @@ jobs:
           instance_type: "m5.4xlarge"
           instance_disk: "40"
           cost_limit: ${{ secrets.GLOBAL_CLOUDOS_JOB_COST_LIMIT }}
+          cloudos_url: "https://staging.lifebit.ai"
           cloudos_cli_flags: "--spot --wait-completion"
 
       - name: Get the cloudos_job_run job ID

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Print cloudos job run command (dry_run set to true)
+      - name: Run cloudos job run command
         uses: lifebit-ai/action-cloudos-cli@0.3.1
         id: cloudos_job_run
         with:

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -21,10 +21,8 @@ jobs:
           git_commit: "${{ github.event.pull_request.head.sha }}"
           instance_type: "m5.4xlarge"
           instance_disk: "40"
+          dry_run: true
           cost_limit: ${{ secrets.GLOBAL_CLOUDOS_JOB_COST_LIMIT }}
           cloudos_cli_flags: "--spot --wait-completion"
-
-      - name: Get the cloudos_job_run job ID
-        run: echo ${{steps.cloudos_job_run.outputs.job_id}}
 
 

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -14,14 +14,14 @@ jobs:
         with:
           apikey:  "${{ secrets.CLOUDOS_TOKEN }}"
           cloudos_url: 'https://staging.lifebit.ai'
-          workspace_id: "${{ secrets.CLOUDOS_WORKSPACE_ID }}"
-          project_name: "cloudos-cli-tests"
+          workspace_id: "6323318f39fff801570a1b62"
+          project_name: "ci-testing"
           workflow_name: "rnatoy"
           nextflow_profile: "test"
           git_commit: "${{ github.event.pull_request.head.sha }}"
           instance_type: "m5.4xlarge"
           instance_disk: "40"
-          cost_limit: "${{ secrets.GLOBAL_CLOUDOS_JOB_COST_LIMIT }}"
+          cost_limit: "2"
           cloudos_cli_flags: "--spot --wait-completion"
 
 

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -1,4 +1,9 @@
-on: [push]
+on:
+   pull_request:
+     types: [review_requested, ready_for_review]
+     branches:
+      - main
+      - dev
 
 jobs:
   custom_test:
@@ -12,16 +17,16 @@ jobs:
         uses: lifebit-ai/action-cloudos-cli@0.3.1
         id: cloudos_job_run
         with:
-          apikey:  "${{ secrets.CLOUDOS_TEMP_TOKEN }}"
+          apikey:  "${{ secrets.CLOUDOS_TOKEN }}"
           cloudos_url: 'https://staging.lifebit.ai'
-          workspace_id: "${{ secrets.CLOUDOS_TEMP_WORKSPACE_ID }}"
+          workspace_id: "${{ secrets.CLOUDOS_WORKSPACE_ID }}"
           project_name: "ci-testing"
-          workflow_name: "rnatoy"
-          nextflow_profile: "test"
+          workflow_name: "etl_profile_clean"
+          nextflow_profile: "internal_ci_profile_clean"
           git_commit: "${{ github.event.pull_request.head.sha }}"
           instance_type: "m5.4xlarge"
           instance_disk: "40"
-          cost_limit: "2"
+          cost_limit: "${{ secrets.GLOBAL_CLOUDOS_JOB_COST_LIMIT }}"
           cloudos_cli_flags: "--spot --wait-completion"
 
 

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -6,9 +6,9 @@ jobs:
     name: Test for cloudos job run
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
-      - name: Run cloudos job run command
+      - name: Print cloudos job run command (dry_run set to true)
         uses: lifebit-ai/action-cloudos-cli@0.3.1
         id: cloudos_job_run
         with:
@@ -20,6 +20,7 @@ jobs:
           nextflow_profile: 'test'
           cloudos_cli_flags: '--resumable --spot --verbose --wait-completion'
           request_interval: 60
+          dry_run: 'false'
           instance_type: 'c5.xlarge'
           instance_disk: 40
           wait_time: 7200

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -12,9 +12,9 @@ jobs:
         uses: lifebit-ai/action-cloudos-cli@0.3.1
         id: cloudos_job_run
         with:
-          apikey:  "${{ secrets.CLOUDOS_TOKEN }}"
+          apikey:  "${{ secrets.CLOUDOS_TEMP_TOKEN }}"
           cloudos_url: 'https://staging.lifebit.ai'
-          workspace_id: "6323318f39fff801570a1b62"
+          workspace_id: "${{ secrets.CLOUDOS_TEMP_WORKSPACE_ID }}"
           project_name: "ci-testing"
           workflow_name: "rnatoy"
           nextflow_profile: "test"

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -21,7 +21,6 @@ jobs:
           git_commit: "${{ github.event.pull_request.head.sha }}"
           instance_type: "m5.4xlarge"
           instance_disk: "40"
-          dry_run: true
           cost_limit: ${{ secrets.GLOBAL_CLOUDOS_JOB_COST_LIMIT }}
           cloudos_cli_flags: "--spot --wait-completion"
 

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -12,7 +12,7 @@ jobs:
         uses: lifebit-ai/action-cloudos-cli@0.3.1
         id: cloudos_job_run
         with:
-          apikey:  ${{ secrets.CLOUDOS_TOKEN }}
+          apikey:  ${{ secrets.CLOUDOS_APIKEY }}
           cloudos_url: 'https://staging.lifebit.ai'
           workspace_id: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
           project_name: "cloudos-cli-tests"

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -26,7 +26,7 @@ jobs:
           git_commit: "${{ github.event.pull_request.head.sha }}"
           instance_type: "m5.4xlarge"
           instance_disk: "40"
-          cost_limit: "${{ secrets.GLOBAL_CLOUDOS_JOB_COST_LIMIT }}"
+          cost_limit: "2"
           cloudos_cli_flags: "--spot --wait-completion"
 
 

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Print cloudos job run command (dry_run set to true)
-        uses: lifebit-ai/action-cloudos-cli@0.3.0
+        uses: lifebit-ai/action-cloudos-cli@0.3.1
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_TOKEN }}

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Print cloudos job run command (dry_run set to true)
-        uses: lifebit-ai/action-cloudos-cli@0.3.0
+        uses: lifebit-ai/action-cloudos-cli@0.3.1
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_APIKEY }}

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -23,7 +23,6 @@ jobs:
           project_name: "ci-testing"
           workflow_name: "etl_profile_clean"
           nextflow_profile: "internal_ci_profile_clean"
-          git_commit: "${{ github.event.pull_request.head.sha }}"
           instance_type: "m5.4xlarge"
           instance_disk: "40"
           cost_limit: "2"

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -12,7 +12,7 @@ jobs:
         uses: lifebit-ai/action-cloudos-cli@0.3.1
         id: cloudos_job_run
         with:
-          apikey:  ${{ secrets.CLOUDOS_TOKEN }}
+          apikey:  "${{ secrets.CLOUDOS_TOKEN }}"
           cloudos_url: 'https://staging.lifebit.ai'
           workspace_id: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
           project_name: "cloudos-cli-tests"

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -23,7 +23,6 @@ jobs:
           instance_type: 'c5.xlarge'
           instance_disk: 40
           wait_time: 7200
-          git_commit: '${{ github.event.pull_request.head.sha }}'
           cost_limit: ${{ secrets.GLOBAL_CLOUDOS_JOB_COST_LIMIT }}
 
       - name: Get the cloudos_job_run job ID

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -14,14 +14,14 @@ jobs:
         with:
           apikey:  "${{ secrets.CLOUDOS_TOKEN }}"
           cloudos_url: 'https://staging.lifebit.ai'
-          workspace_id: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
+          workspace_id: "${{ secrets.CLOUDOS_WORKSPACE_ID }}"
           project_name: "cloudos-cli-tests"
           workflow_name: "rnatoy"
           nextflow_profile: "test"
           git_commit: "${{ github.event.pull_request.head.sha }}"
           instance_type: "m5.4xlarge"
           instance_disk: "40"
-          cost_limit: ${{ secrets.GLOBAL_CLOUDOS_JOB_COST_LIMIT }}
+          cost_limit: "${{ secrets.GLOBAL_CLOUDOS_JOB_COST_LIMIT }}"
           cloudos_cli_flags: "--spot --wait-completion"
 
 

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -15,13 +15,13 @@ jobs:
           apikey:  ${{ secrets.CLOUDOS_TOKEN }}
           cloudos_url: 'https://staging.lifebit.ai'
           workspace_id: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
-          project_name: "cloudos-cli-tests"
-          workflow_name: "rnatoy"
-          nextflow_profile: "test"
-          git_commit: "${{ github.event.pull_request.head.sha }}"
-          instance_type: "m5.4xlarge"
-          instance_disk: "40"
+          project_name: 'ci-testing'
+          workflow_name: 'etl_profile_clean'
+          nextflow_profile: 'meta_ci_testing'
+          git_commit: '${{ github.event.pull_request.head.sha }}'
+          instance_type: 'm5.4xlarge'
+          instance_disk: '40'
           cost_limit: ${{ secrets.GLOBAL_CLOUDOS_JOB_COST_LIMIT }}
-          cloudos_cli_flags: "--spot --wait-completion"
+          cloudos_cli_flags: '--spot --wait-completion'
 
 

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -28,4 +28,5 @@ jobs:
           cost_limit: "2"
           cloudos_cli_flags: "--spot --wait-completion"
 
-
+      - name: Get the cloudos_job_run job ID
+        run: echo ${{steps.cloudos_job_run.outputs.job_id}}

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -12,6 +12,7 @@ jobs:
         uses: lifebit-ai/action-cloudos-cli@0.3.1
         id: cloudos_job_run
         with:
+          cloudos_url: "https://staging.lifebit.ai"
           apikey:  ${{ secrets.CLOUDOS_TOKEN }}
           workspace_id: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
           project_name: "cloudos-cli-tests"
@@ -22,7 +23,6 @@ jobs:
           instance_disk: "40"
           cost_limit: ${{ secrets.GLOBAL_CLOUDOS_JOB_COST_LIMIT }}
           cloudos_cli_flags: "--spot --wait-completion"
-          cloudos_url: "https://staging.lifebit.ai"
 
       - name: Get the cloudos_job_run job ID
         run: echo ${{steps.cloudos_job_run.outputs.job_id}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Base image
-FROM quay.io/lifebitaiorg/cloudos-cli:v1.3.2
+FROM quay.io/lifebitaiorg/cloudos-cli:v2.0.0
 
 # installes required packages for our script
-RUN	apt install -y \
+RUN apt-get update && apt install -y \
   bash \
   ca-certificates \
   curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM quay.io/lifebitaiorg/cloudos-cli:v1.1.0
+FROM quay.io/lifebitaiorg/cloudos-cli:v1.3.2
 
 # installes required packages for our script
 RUN	apt install -y \

--- a/action.yaml
+++ b/action.yaml
@@ -63,7 +63,7 @@ inputs:
   repository_platform:
     description: 'Name of the repository platform of the workflow. Default=github.'
     required: false
-  request_interval: 
+  request_interval:
     description: 'Request interval in seconds. The options is influencing the request interval for receiving the job status when --wait-completion is used'
     required: false
   cost_limit:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,4 +37,4 @@ then
 else
     job_id=""
 fi
-echo "::set-output name=job_id::$job_id"
+echo "{job_id}={$job_id}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Overview

This PR Updates the CloudOS container used by the action, changes the deprecated command (following: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) and updates ci testing.

## Changes

- Changes container in: `Dockerfile`,
- updates ci tests in: `.github/workflows/cloudos-ci.yml`,
- changes the deprecated command in: `entrypoint.sh`.

## How to test

Staging: https://staging.lifebit.ai/app/jobs/6402056dfd9d53ae5d90d429

## PR Checklist:

I confirm that:

- [ ] all changes/additions are documented
- [ ] ci tests added