### PR TITLE
Updates cloudos-cli to 2.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM quay.io/lifebitaiorg/cloudos-cli:v2.0.0
+FROM quay.io/lifebitaiorg/cloudos-cli:v2.6.0
 
 # installes required packages for our script
 RUN apt-get update && apt install -y \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Echo cloudos command
-        uses: lifebit-ai/action-cloudos-cli@0.2.0
+        uses: lifebit-ai/action-cloudos-cli@0.3.3
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_APIKEY }}
@@ -24,7 +24,8 @@ jobs:
           project_name: 'cloudos-cli-tests'
           workflow_name: 'cgpu/rnatoy'
           nextflow_profile: 'test'
-          cloudos_cli_flags: '--resumable --spot'
+          cost_limit: 2
+          cloudos_cli_flags: '--resumable --spot --batch'
 ```
 
 
@@ -80,6 +81,10 @@ The version tag of the chosen workflow repository. It must exist in the reposito
 
 A name to assign to the job run.
 
+### `execution_platform`
+
+Name of the cloud provider used in your CloudOS workspace. Available options: [`aws`, `azure`]. Default: `aws`
+
 ### `instance_type`
 
 The type of AWS EC2 instance to use as master node for the job eg c5.xlarge
@@ -123,6 +128,10 @@ Cost limit in USD. If the job exceeds the defined cost limit, the job will be ab
 ### `request_interval`
 
 Request interval in seconds. The options is influencing the request interval for receiving the job status when `--wait-completion` is used. The default value is the same as the default of [](https://github.com/lifebit-ai/cloudos-cli).
+
+### `job_queue`
+
+Name of the job batch queue to use with a batch job execution. Default: workspace default. The parameter is optional and conditional to only when using `--batch`. If `--batch` is not used, the parameter will be ignored.
 
 ### `cloudos_cli_flags`
 

--- a/action.yaml
+++ b/action.yaml
@@ -36,8 +36,11 @@ inputs:
     description: 'A name to assign to the job run.'
     required: true
     default: job-via-github-actions-ci
+  execution_platform:
+    description: 'Name of the cloud provider used in your CloudOS workspace. Available options: [aws, azure]. Default: aws'
+    required: false
   instance_type:
-    description: 'The type of AWS EC2 instance to use as master node for the job eg c5.xlarge'
+    description: 'Name of the virtual machine type as defined by the respective cloud provider to use as master node for the job. Default conditional to the cloud provider: c5.xlarge (aws) or Standard_D4as_v4 (azure).'
     required: false
   instance_disk:
     description: 'Disk storage in GB to be used for the master node vm.'
@@ -69,6 +72,9 @@ inputs:
   cost_limit:
     description: 'Cost limit in USD. If the job exceeds the defined cost limit, the job will be aborted. It is advised to always use a cost limit.'
     required: false
+  job_queue:
+    description: "Name of the job batch queue to use with a batch job execution. Default: workspace default."
+    required: false
   cloudos_cli_flags:
     description: 'Additional cloudos-cli flags, space separated eg "--spot --resumable". Available options: [--spot, --batch, --resumable, --verbose, --wait-completion]'
     required: false
@@ -76,7 +82,6 @@ inputs:
   dry_run:
     description: 'Mode of execution for the action, by default the API call will be sent. Set to dry_run: true if you only want to print the command (strips secrets before printing).'
     required: false
-    default: false
 outputs:
    job_id:
      description: 'Job ID from Lifebit CloudOS cloudos-cli'
@@ -94,6 +99,7 @@ runs:
     - ${{ inputs.git_commit }}
     - ${{ inputs.git_tag }}
     - ${{ inputs.job_name }}
+    - ${{ inputs.execution_platform }}
     - ${{ inputs.instance_type }}
     - ${{ inputs.instance_disk }}
     - ${{ inputs.storage_mode }}
@@ -104,5 +110,7 @@ runs:
     - ${{ inputs.cromwell_token }}
     - ${{ inputs.repository_platform }}
     - ${{ inputs.request_interval}}
+    - ${{ inputs.cost_limit}}
+    - ${{ inputs.job_queue}}
     - ${{ inputs.cloudos_cli_flags}}
     - ${{ inputs.dry_run}}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,7 @@ if [[ ${INPUT_NEXTFLOW_PROFILE} ]];    then CLOUDOS_RUN_CMD+=" --nextflow-profil
 if [[ ${INPUT_GIT_COMMIT} ]];          then CLOUDOS_RUN_CMD+=" --git-commit ${INPUT_GIT_COMMIT}" ; fi
 if [[ ${INPUT_GIT_TAG} ]];             then CLOUDOS_RUN_CMD+=" --git-tag ${INPUT_GIT_TAG}" ; fi
 if [[ ${INPUT_JOB_NAME} ]];            then CLOUDOS_RUN_CMD+=" --job-name ${INPUT_JOB_NAME}" ; fi
+if [[ ${INPUT_EXECUTION_PLATFORM} ]];        then CLOUDOS_RUN_CMD+=" --execution-platform ${EXECUTION_PLATFORM}" ; fi
 if [[ ${INPUT_INSTANCE_TYPE} ]];       then CLOUDOS_RUN_CMD+=" --instance-type ${INPUT_INSTANCE_TYPE}" ; fi
 if [[ ${INPUT_INSTANCE_DISK} ]];       then CLOUDOS_RUN_CMD+=" --instance-disk ${INPUT_INSTANCE_DISK}" ; fi
 if [[ ${INPUT_STORAGE_MODE} ]];        then CLOUDOS_RUN_CMD+=" --storage-mode ${INPUT_STORAGE_MODE}" ; fi
@@ -24,7 +25,8 @@ if [[ ${INPUT_WDL_IMPORTSFILE} ]];     then CLOUDOS_RUN_CMD+=" --wdl-importsfile
 if [[ ${INPUT_CROMWELL_TOKEN} ]];      then CLOUDOS_RUN_CMD+=" --cromwell-token ${INPUT_CROMWELL_TOKEN}" ; fi
 if [[ ${INPUT_REPOSITORY_PLATFORM} ]]; then CLOUDOS_RUN_CMD+=" --repository-platform ${INPUT_REPOSITORY_PLATFORM}" ; fi
 if [[ ${INPUT_REQUEST_INTERVAL} ]];    then CLOUDOS_RUN_CMD+=" --request-interval ${INPUT_REQUEST_INTERVAL}" ; fi
-if [[ ${INPUT_COST_LIMIT} ]];          then CLOUDOS_RUN_CMD+=" --cost-limit ${INPUT_COST_LIMIT}" ; fi
+if [[ ${INPUT_COST_LIMIT} ]];          then CLOUDOS_RUN_CMD+=" --job-queue ${INPUT_JOB_QUEUE}" ; fi
+if [[ ${INPUT_JOB_QUEUE} ]];           then CLOUDOS_RUN_CMD+=" --cost-limit ${INPUT_COST_LIMIT}" ; fi
 if [[ ${INPUT_CLOUDOS_CLI_FLAGS} ]];   then CLOUDOS_RUN_CMD+=" ${INPUT_CLOUDOS_CLI_FLAGS}" ; fi
 
 echo "Command: "


### PR DESCRIPTION
Updates the version of the cloudos-cli

The 0.3.3 release for action-cloudos-cli includes

## Feat

- Adds support for Azure as the cloud provider (`--execution-platform`)

## Fix

- Adds missing parameters implemented in previous versions (`--job-queue`, `--cost-limit`)