### PR TITLE
Feat: Bumps to cloudos-cli 2.11.2

### DIFF
--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run cloudos job run command
-        uses: lifebit-ai/action-cloudos-cli@0.3.2
+        uses: lifebit-ai/action-cloudos-cli@0.3.5
         id: cloudos_job_run
         with:
           apikey:  "${{ secrets.CLOUDOS_TOKEN }}"
@@ -26,7 +26,7 @@ jobs:
           instance_type: "m5.4xlarge"
           instance_disk: "40"
           cost_limit: "2"
-          cloudos_cli_flags: "--spot --wait-completion"
+          cloudos_cli_flags: "--resumable"
 
       - name: Get the cloudos_job_run job ID
         run: echo ${{steps.cloudos_job_run.outputs.job_id}}

--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -18,7 +18,7 @@ jobs:
         id: cloudos_job_run
         with:
           apikey:  "${{ secrets.CLOUDOS_TOKEN }}"
-          cloudos_url: 'https://staging.lifebit.ai'
+          cloudos_url: 'https://stg.sdlc.lifebit.ai'
           workspace_id: "${{ secrets.CLOUDOS_WORKSPACE_ID }}"
           project_name: "ci-testing"
           workflow_name: "etl_profile_clean"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM quay.io/lifebitaiorg/cloudos-cli:v2.0.0
+FROM quay.io/lifebitaiorg/cloudos-cli:v2.6.0
 
 # installes required packages for our script
 RUN apt-get update && apt install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM quay.io/lifebitaiorg/cloudos-cli:v2.6.0
+FROM quay.io/lifebitaiorg/cloudos-cli:v2.11.2
 
 # installes required packages for our script
 RUN apt-get update && apt install -y \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Echo cloudos command
-        uses: lifebit-ai/action-cloudos-cli@0.2.0
+        uses: lifebit-ai/action-cloudos-cli@0.3.3
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_APIKEY }}
@@ -24,7 +24,8 @@ jobs:
           project_name: 'cloudos-cli-tests'
           workflow_name: 'cgpu/rnatoy'
           nextflow_profile: 'test'
-          cloudos_cli_flags: '--resumable --spot'
+          cost_limit: 2
+          cloudos_cli_flags: '--resumable --spot --batch'
 ```
 
 
@@ -80,6 +81,10 @@ The version tag of the chosen workflow repository. It must exist in the reposito
 
 A name to assign to the job run.
 
+### `execution_platform`
+
+Name of the cloud provider used in your CloudOS workspace. Available options: [`aws`, `azure`]. Default: `aws`
+
 ### `instance_type`
 
 The type of AWS EC2 instance to use as master node for the job eg c5.xlarge
@@ -123,6 +128,10 @@ Cost limit in USD. If the job exceeds the defined cost limit, the job will be ab
 ### `request_interval`
 
 Request interval in seconds. The options is influencing the request interval for receiving the job status when `--wait-completion` is used. The default value is the same as the default of [](https://github.com/lifebit-ai/cloudos-cli).
+
+### `job_queue`
+
+Name of the job batch queue to use with a batch job execution. Default: workspace default. The parameter is optional and conditional to only when using `--batch`. If `--batch` is not used, the parameter will be ignored.
 
 ### `cloudos_cli_flags`
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Echo cloudos command
-        uses: lifebit-ai/action-cloudos-cli@0.3.3
+        uses: lifebit-ai/action-cloudos-cli@0.3.5
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_APIKEY }}
@@ -25,7 +25,7 @@ jobs:
           workflow_name: 'cgpu/rnatoy'
           nextflow_profile: 'test'
           cost_limit: 2
-          cloudos_cli_flags: '--resumable --spot --batch'
+          cloudos_cli_flags: '--resumable'
 ```
 
 
@@ -129,13 +129,9 @@ Cost limit in USD. If the job exceeds the defined cost limit, the job will be ab
 
 Request interval in seconds. The options is influencing the request interval for receiving the job status when `--wait-completion` is used. The default value is the same as the default of [](https://github.com/lifebit-ai/cloudos-cli).
 
-### `job_queue`
-
-Name of the job batch queue to use with a batch job execution. Default: workspace default. The parameter is optional and conditional to only when using `--batch`. If `--batch` is not used, the parameter will be ignored.
-
 ### `cloudos_cli_flags`
 
-Additional cloudos-cli flags, space separated eg `'--spot --resumable'`. Available options: `[--spot, --batch, --resumable, --verbose, --wait-completion]`
+Additional cloudos-cli flags, space separated eg `'--resumable'`. Available options: `[--resumable, --verbose, --wait-completion]`
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Specific Cromwell server authentication token. Only required for WDL jobs.
 
 Name of the repository platform of the workflow. Default=github.
 
+### `job_queue`
+
+Name of the job batch queue to use with a batch job execution. Default: workspace default.
+
 ### `cost_limit`
 
 Cost limit in USD. If the job exceeds the defined cost limit, the job will be aborted. :warning: It is advised to always use a cost limit to avoid jobs running indefinitely if there is a pipeline issue.

--- a/action.yaml
+++ b/action.yaml
@@ -72,9 +72,6 @@ inputs:
   cost_limit:
     description: 'Cost limit in USD. If the job exceeds the defined cost limit, the job will be aborted. It is advised to always use a cost limit.'
     required: false
-  job_queue:
-    description: "Name of the job batch queue to use with a batch job execution. Default: workspace default."
-    required: false
   cloudos_cli_flags:
     description: 'Additional cloudos-cli flags, space separated eg "--spot --resumable". Available options: [--spot, --batch, --resumable, --verbose, --wait-completion]'
     required: false
@@ -111,6 +108,5 @@ runs:
     - ${{ inputs.repository_platform }}
     - ${{ inputs.request_interval}}
     - ${{ inputs.cost_limit}}
-    - ${{ inputs.job_queue}}
     - ${{ inputs.cloudos_cli_flags}}
     - ${{ inputs.dry_run}}

--- a/action.yaml
+++ b/action.yaml
@@ -69,11 +69,14 @@ inputs:
   request_interval:
     description: 'Request interval in seconds. The options is influencing the request interval for receiving the job status when --wait-completion is used'
     required: false
+  job_queue:
+    description: "Name of the job batch queue to use with a batch job execution. Default: workspace default."
+    required: false
   cost_limit:
     description: 'Cost limit in USD. If the job exceeds the defined cost limit, the job will be aborted. It is advised to always use a cost limit.'
     required: false
   cloudos_cli_flags:
-    description: 'Additional cloudos-cli flags, space separated eg "--spot --resumable". Available options: [--spot, --batch, --resumable, --verbose, --wait-completion]'
+    description: 'Additional cloudos-cli flags, space separated eg "--resumable". Available options: [--resumable, --verbose, --wait-completion]'
     required: false
     default: ''
   dry_run:
@@ -107,6 +110,7 @@ runs:
     - ${{ inputs.cromwell_token }}
     - ${{ inputs.repository_platform }}
     - ${{ inputs.request_interval}}
+    - ${{ inputs.job_queue}}
     - ${{ inputs.cost_limit}}
     - ${{ inputs.cloudos_cli_flags}}
     - ${{ inputs.dry_run}}

--- a/action.yaml
+++ b/action.yaml
@@ -36,8 +36,11 @@ inputs:
     description: 'A name to assign to the job run.'
     required: true
     default: job-via-github-actions-ci
+  execution_platform:
+    description: 'Name of the cloud provider used in your CloudOS workspace. Available options: [aws, azure]. Default: aws'
+    required: false
   instance_type:
-    description: 'The type of AWS EC2 instance to use as master node for the job eg c5.xlarge'
+    description: 'Name of the virtual machine type as defined by the respective cloud provider to use as master node for the job. Default conditional to the cloud provider: c5.xlarge (aws) or Standard_D4as_v4 (azure).'
     required: false
   instance_disk:
     description: 'Disk storage in GB to be used for the master node vm.'
@@ -69,6 +72,9 @@ inputs:
   cost_limit:
     description: 'Cost limit in USD. If the job exceeds the defined cost limit, the job will be aborted. It is advised to always use a cost limit.'
     required: false
+  job_queue:
+    description: "Name of the job batch queue to use with a batch job execution. Default: workspace default."
+    required: false
   cloudos_cli_flags:
     description: 'Additional cloudos-cli flags, space separated eg "--spot --resumable". Available options: [--spot, --batch, --resumable, --verbose, --wait-completion]'
     required: false
@@ -76,7 +82,6 @@ inputs:
   dry_run:
     description: 'Mode of execution for the action, by default the API call will be sent. Set to dry_run: true if you only want to print the command (strips secrets before printing).'
     required: false
-    default: false
 outputs:
    job_id:
      description: 'Job ID from Lifebit CloudOS cloudos-cli'
@@ -94,6 +99,7 @@ runs:
     - ${{ inputs.git_commit }}
     - ${{ inputs.git_tag }}
     - ${{ inputs.job_name }}
+    - ${{ inputs.execution_platform }}
     - ${{ inputs.instance_type }}
     - ${{ inputs.instance_disk }}
     - ${{ inputs.storage_mode }}
@@ -104,5 +110,7 @@ runs:
     - ${{ inputs.cromwell_token }}
     - ${{ inputs.repository_platform }}
     - ${{ inputs.request_interval}}
+    - ${{ inputs.cost_limit}}
+    - ${{ inputs.job_queue}}
     - ${{ inputs.cloudos_cli_flags}}
     - ${{ inputs.dry_run}}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,8 @@ if [[ ${INPUT_WDL_IMPORTSFILE} ]];     then CLOUDOS_RUN_CMD+=" --wdl-importsfile
 if [[ ${INPUT_CROMWELL_TOKEN} ]];      then CLOUDOS_RUN_CMD+=" --cromwell-token ${INPUT_CROMWELL_TOKEN}" ; fi
 if [[ ${INPUT_REPOSITORY_PLATFORM} ]]; then CLOUDOS_RUN_CMD+=" --repository-platform ${INPUT_REPOSITORY_PLATFORM}" ; fi
 if [[ ${INPUT_REQUEST_INTERVAL} ]];    then CLOUDOS_RUN_CMD+=" --request-interval ${INPUT_REQUEST_INTERVAL}" ; fi
-if [[ ${INPUT_COST_LIMIT} ]];          then CLOUDOS_RUN_CMD+=" --job-queue ${INPUT_JOB_QUEUE}" ; fi
+if [[ ${INPUT_JOB_QUEUE} ]];          then CLOUDOS_RUN_CMD+=" --job-queue ${INPUT_JOB_QUEUE}" ; fi
+if [[ ${INPUT_COST_LIMIT} ]];           then CLOUDOS_RUN_CMD+=" --cost-limit ${INPUT_COST_LIMIT}" ; fi
 if [[ ${INPUT_CLOUDOS_CLI_FLAGS} ]];   then CLOUDOS_RUN_CMD+=" ${INPUT_CLOUDOS_CLI_FLAGS}" ; fi
 
 echo "Command: "

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,6 @@ if [[ ${INPUT_CROMWELL_TOKEN} ]];      then CLOUDOS_RUN_CMD+=" --cromwell-token 
 if [[ ${INPUT_REPOSITORY_PLATFORM} ]]; then CLOUDOS_RUN_CMD+=" --repository-platform ${INPUT_REPOSITORY_PLATFORM}" ; fi
 if [[ ${INPUT_REQUEST_INTERVAL} ]];    then CLOUDOS_RUN_CMD+=" --request-interval ${INPUT_REQUEST_INTERVAL}" ; fi
 if [[ ${INPUT_COST_LIMIT} ]];          then CLOUDOS_RUN_CMD+=" --job-queue ${INPUT_JOB_QUEUE}" ; fi
-if [[ ${INPUT_JOB_QUEUE} ]];           then CLOUDOS_RUN_CMD+=" --cost-limit ${INPUT_COST_LIMIT}" ; fi
 if [[ ${INPUT_CLOUDOS_CLI_FLAGS} ]];   then CLOUDOS_RUN_CMD+=" ${INPUT_CLOUDOS_CLI_FLAGS}" ; fi
 
 echo "Command: "

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,7 @@ if [[ ${INPUT_NEXTFLOW_PROFILE} ]];    then CLOUDOS_RUN_CMD+=" --nextflow-profil
 if [[ ${INPUT_GIT_COMMIT} ]];          then CLOUDOS_RUN_CMD+=" --git-commit ${INPUT_GIT_COMMIT}" ; fi
 if [[ ${INPUT_GIT_TAG} ]];             then CLOUDOS_RUN_CMD+=" --git-tag ${INPUT_GIT_TAG}" ; fi
 if [[ ${INPUT_JOB_NAME} ]];            then CLOUDOS_RUN_CMD+=" --job-name ${INPUT_JOB_NAME}" ; fi
+if [[ ${INPUT_EXECUTION_PLATFORM} ]];        then CLOUDOS_RUN_CMD+=" --execution-platform ${EXECUTION_PLATFORM}" ; fi
 if [[ ${INPUT_INSTANCE_TYPE} ]];       then CLOUDOS_RUN_CMD+=" --instance-type ${INPUT_INSTANCE_TYPE}" ; fi
 if [[ ${INPUT_INSTANCE_DISK} ]];       then CLOUDOS_RUN_CMD+=" --instance-disk ${INPUT_INSTANCE_DISK}" ; fi
 if [[ ${INPUT_STORAGE_MODE} ]];        then CLOUDOS_RUN_CMD+=" --storage-mode ${INPUT_STORAGE_MODE}" ; fi
@@ -24,7 +25,8 @@ if [[ ${INPUT_WDL_IMPORTSFILE} ]];     then CLOUDOS_RUN_CMD+=" --wdl-importsfile
 if [[ ${INPUT_CROMWELL_TOKEN} ]];      then CLOUDOS_RUN_CMD+=" --cromwell-token ${INPUT_CROMWELL_TOKEN}" ; fi
 if [[ ${INPUT_REPOSITORY_PLATFORM} ]]; then CLOUDOS_RUN_CMD+=" --repository-platform ${INPUT_REPOSITORY_PLATFORM}" ; fi
 if [[ ${INPUT_REQUEST_INTERVAL} ]];    then CLOUDOS_RUN_CMD+=" --request-interval ${INPUT_REQUEST_INTERVAL}" ; fi
-if [[ ${INPUT_COST_LIMIT} ]];          then CLOUDOS_RUN_CMD+=" --cost-limit ${INPUT_COST_LIMIT}" ; fi
+if [[ ${INPUT_COST_LIMIT} ]];          then CLOUDOS_RUN_CMD+=" --job-queue ${INPUT_JOB_QUEUE}" ; fi
+if [[ ${INPUT_JOB_QUEUE} ]];           then CLOUDOS_RUN_CMD+=" --cost-limit ${INPUT_COST_LIMIT}" ; fi
 if [[ ${INPUT_CLOUDOS_CLI_FLAGS} ]];   then CLOUDOS_RUN_CMD+=" ${INPUT_CLOUDOS_CLI_FLAGS}" ; fi
 
 echo "Command: "


### PR DESCRIPTION
Updates cloudos-cli version to 2.11.2 to deprecate API key via parameters. This PR is superseding https://github.com/lifebit-ai/action-cloudos-cli/pull/29

The 0.3.5 release for action-cloudos-cli includes

## Feat

- cloudos-cli version 2.11.2
- Adds support for Azure as the cloud provider (`--execution-platform`)

## Fix

- Adds missing parameters implemented in previous versions (`--job-queue`, `--cost-limit`)