### PR TITLE
Feat: bumps to cloudos-cli 2.15.0

### DIFF
--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run cloudos job run command
-        uses: lifebit-ai/action-cloudos-cli@0.3.5
+        uses: lifebit-ai/action-cloudos-cli@0.3.6
         id: cloudos_job_run
         with:
           apikey:  "${{ secrets.CLOUDOS_TOKEN }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM quay.io/lifebitaiorg/cloudos-cli:v2.11.2
+FROM quay.io/lifebitaiorg/cloudos-cli:v2.15.0
 
 # installes required packages for our script
 RUN apt-get update && apt install -y \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Echo cloudos command
-        uses: lifebit-ai/action-cloudos-cli@0.3.5
+        uses: lifebit-ai/action-cloudos-cli@0.3.6
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_APIKEY }}


### PR DESCRIPTION
Updates cloudos-cli version to 2.15.0. This cloudos-cli version use get_/v3/workflows endpoint in preparation for the v1 endpoint deprecation.

The 0.3.6 release for action-cloudos-cli includes

## Feat

- cloudos-cli version 2.15.0