### PR TITLE
feat: bumps cloudos-cli to v2.59.0

### DIFF
--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run cloudos job run command
-        uses: lifebit-ai/action-cloudos-cli@0.3.6
+        uses: lifebit-ai/action-cloudos-cli@0.3.7
         id: cloudos_job_run
         with:
           apikey:  "${{ secrets.CLOUDOS_TOKEN }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM quay.io/lifebitaiorg/cloudos-cli:v2.15.0
+FROM quay.io/lifebitaiorg/cloudos-cli:v2.59.0
 
 # installes required packages for our script
 RUN apt-get update && apt install -y \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Echo cloudos command
-        uses: lifebit-ai/action-cloudos-cli@0.3.6
+        uses: lifebit-ai/action-cloudos-cli@0.3.7
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_APIKEY }}


### PR DESCRIPTION
## Overview

Currently, CI tests don't work due to the old CLI version used in this action. This PR updates CLI to the latest version and solves the issue