### PR TITLE
feat: updates CLI version to 2.75.0

### DIFF
--- a/.github/workflows/cloudos-ci.yml
+++ b/.github/workflows/cloudos-ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run cloudos job run command
-        uses: lifebit-ai/action-cloudos-cli@0.3.7
+        uses: lifebit-ai/action-cloudos-cli@0.3.8
         id: cloudos_job_run
         with:
           apikey:  "${{ secrets.CLOUDOS_TOKEN }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM quay.io/lifebitaiorg/cloudos-cli:v2.59.0
+FROM quay.io/lifebitaiorg/cloudos-cli:v2.75.0
 
 # installes required packages for our script
 RUN apt-get update && apt install -y \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Echo cloudos command
-        uses: lifebit-ai/action-cloudos-cli@0.3.7
+        uses: lifebit-ai/action-cloudos-cli@0.3.8
         id: cloudos_job_run
         with:
           apikey:  ${{ secrets.CLOUDOS_APIKEY }}


### PR DESCRIPTION
## Overview

This PR updates the CLI version from 2.59.0 to 2.75.0. This update is required to support last Platform updates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update CloudOS CLI versions: GitHub Action to 0.3.8 and Docker base image to v2.75.0.
> 
> - **CI/Workflows**:
>   - Update `lifebit-ai/action-cloudos-cli` to `0.3.8` in `.github/workflows/cloudos-ci.yml`.
> - **Docker**:
>   - Bump base image `quay.io/lifebitaiorg/cloudos-cli` from `v2.59.0` to `v2.75.0` in `Dockerfile`.
> - **Docs**:
>   - Update README example to use `lifebit-ai/action-cloudos-cli@0.3.8`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6623a1fd7435b63a8fc709d76284ab1b85217c55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->